### PR TITLE
Adding 'raw' filter to template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ And you're done!
 {% for asset in assets %}
 	{% set embed = craft.embeddedAssets.fromAsset(asset) %}
 	{% if embed %}
-		{{ embed.safeHtml }}
+		{{ embed.safeHtml|raw }}
 	{% endif %}
 {% endfor %}
 ```


### PR DESCRIPTION
Adding the 'raw' filter was the only way I could get the output tag to work properly. I found this recommendation in a closed issue, but some people might not know to look there. If `{{ embed.safeHtml|raw }}` works more consistently, perhaps that should be in the example?