### PR TITLE
Clean filename when storing

### DIFF
--- a/embeddedassets/services/EmbeddedAssetsService.php
+++ b/embeddedassets/services/EmbeddedAssetsService.php
@@ -214,7 +214,7 @@ class EmbeddedAssetsService extends BaseApplicationComponent
 		$fileLabel = substr(preg_replace('/[^a-z0-9]+/i', '-', $media->getTitle()), 0, 40);
 		$filePrefix = EmbeddedAssetsPlugin::getFileNamePrefix();
 		$fileExtension = '.json';
-		$fileName = $filePrefix . $fileLabel . $fileExtension;
+		$fileName = AssetsHelper::cleanAssetName($filePrefix . $fileLabel . $fileExtension);
 
 		$existingFile = craft()->assets->findFile(array(
 			'folderId' => $folderId,


### PR DESCRIPTION
Fixes #44 

Without cleaning the filename first, you will run into trouble the extra .json files being created (see details in #44)