### PR TITLE
Fix failing schematic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
 
-### v0.4.0
+### v0.4.1
+- `Fixed` Fixed issue with asset source directories using environment variables
+
+#### v0.4.0
 - `Improved` Big performance improvement when loading embedded asset thumbnails in the control panel
 - `Improved` Local embedded assets are now read by their path, improving server's ability to read embedded assets (thanks @awcross)
 - `Improved` Relative URL's now work with thumbnails and URL's in embedded asset data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### v0.4.0
+- `Improved` Big performance improvement when loading embedded asset thumbnails in the control panel
+- `Improved` Local embedded assets are now read by their path, improving server's ability to read embedded assets (thanks @awcross)
+- `Improved` Relative URL's now work with thumbnails and URL's in embedded asset data
+- `Fixed` Fixed issue on some servers when saving embedded asset files (thanks @leevigraham)
+- `Fixed` Fixed issue where some embedded assets would create multiple files (thanks @timkelty)
+
 #### v0.3.4
 - `Improved` Getting thumbnails is now more reliable (cheers @mmikkel)
 - `Improved` Added logging at all critical points to aid in diagnosing issues

--- a/embeddedassets/EmbeddedAssetsPlugin.php
+++ b/embeddedassets/EmbeddedAssetsPlugin.php
@@ -236,6 +236,13 @@ class EmbeddedAssetsPlugin extends BasePlugin
 	 */
 	public function prepSettings($postSettings)
 	{
+		if ( is_array($postSettings['whitelist'])) {
+			// Assume this is already processed, i.e. in the context of
+			// importing through a tool such as Schematic.
+			// Return early
+			return $postSettings;
+		}
+
 		$settings = array(
 			'whitelist' => array_map(function($domain)
 			{

--- a/embeddedassets/EmbeddedAssetsPlugin.php
+++ b/embeddedassets/EmbeddedAssetsPlugin.php
@@ -23,7 +23,7 @@ class EmbeddedAssetsPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '0.3.4';
+		return '0.4.0';
 	}
 
 	public function getSchemaVersion()

--- a/embeddedassets/EmbeddedAssetsPlugin.php
+++ b/embeddedassets/EmbeddedAssetsPlugin.php
@@ -23,7 +23,7 @@ class EmbeddedAssetsPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '0.4.0';
+		return '0.4.1';
 	}
 
 	public function getSchemaVersion()

--- a/embeddedassets/services/EmbeddedAssetsService.php
+++ b/embeddedassets/services/EmbeddedAssetsService.php
@@ -203,6 +203,7 @@ class EmbeddedAssetsService extends BaseApplicationComponent
 		if(strtolower($assetSource->type) == 'local')
 		{
 			$path = $assetSource->settings['path'] . $asset->getFolder()->path . $asset->filename;
+			$path = craft()->config->parseEnvironmentString($path);
 			$assetPath = realpath($path);
 		}
 		else

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,7 @@
 [
 	{
 		"version": "0.4.1",
-		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.4.0.zip",
+		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.4.1.zip",
 		"date": "2017-02-23T12:00:00-08:00",
 		"notes": [
 			"[Fixed] Fixed issue with asset source directories using environment variables"

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,17 @@
 [
 	{
+		"version": "0.4.0",
+		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.4.0.zip",
+		"date": "2017-02-15T15:30:00-08:00",
+		"notes": [
+			"[Improved] Big performance improvement when loading embedded asset thumbnails in the control panel",
+			"[Improved] Local embedded assets are now read by their path, improving server's ability to read embedded assets (thanks @awcross)",
+			"[Improved] Relative URL's now work with thumbnails and URL's in embedded asset data",
+			"[Fixed] Fixed issue on some servers when saving embedded asset files (thanks @leevigraham)",
+			"[Fixed] Fixed issue where some embedded assets would create multiple files (thanks @timkelty)"
+		]
+	},
+	{
 		"version": "0.3.4",
 		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.3.4.zip",
 		"date": "2016-09-10T13:38:00+10:00",

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,13 @@
 [
 	{
+		"version": "0.4.1",
+		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.4.0.zip",
+		"date": "2017-02-23T12:00:00-08:00",
+		"notes": [
+			"[Fixed] Fixed issue with asset source directories using environment variables"
+		]
+	},
+	{
 		"version": "0.4.0",
 		"downloadUrl": "https://github.com/benjamminf/craft-embedded-assets/archive/0.4.0.zip",
 		"date": "2017-02-15T15:30:00-08:00",


### PR DESCRIPTION
We are using a combination of Schematics to codify our settings and embedded assets to show content on our website. When using an import with schematics, it fails on the `prepSettings` call, since that function expects form data, but receives the already processed data that was exported with schematics.

Since that principle is not tied to Schematics itself, but to any form of import/export, and because of https://github.com/nerds-and-company/schematic/issues/87