### PR TITLE
Fix import of Embedded Assets through Schematics

### DIFF
--- a/embeddedassets/EmbeddedAssetsPlugin.php
+++ b/embeddedassets/EmbeddedAssetsPlugin.php
@@ -236,6 +236,13 @@ class EmbeddedAssetsPlugin extends BasePlugin
 	 */
 	public function prepSettings($postSettings)
 	{
+		if ( is_array($postSettings['whitelist'])) {
+			// Assume this is already processed, i.e. in the context of
+			// importing through a tool such as Schematic.
+			// Return early
+			return $postSettings;
+		}
+
 		$settings = array(
 			'whitelist' => array_map(function($domain)
 			{


### PR DESCRIPTION
We are using a combination of Schematics to codify our settings and embedded assets to show content on our website. When using an import with schematics, it fails on the prepSettings call, since that function expects form data, but receives the already processed data that was exported with schematics.

Since that principle is not tied to Schematics itself, but to any form of import/export, and because of nerds-and-company/schematic#87