### PR TITLE
Accept `null` in the `Variable::get()` method

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -37,6 +37,7 @@ use yii\base\Event;
  * @author Spicy Web <craft@spicyweb.com.au>
  * @author Benjamin Fleming
  * @since 1.0.0
+ * @property-read Service $methods
  */
 class Plugin extends BasePlugin
 {

--- a/src/Service.php
+++ b/src/Service.php
@@ -112,7 +112,7 @@ class Service extends Component
         if ($pluginSettings->googleKey) {
             $embedSettings['google:key'] = Craft::parseEnv($pluginSettings->googleKey);
         }
-        if ($pluginSettings->facebookKey) {
+                if ($pluginSettings->facebookKey) {
             $embedSettings['facebook:token'] = $embedSettings['instagram:token'] = Craft::parseEnv($pluginSettings->facebookKey);
         }
 
@@ -199,10 +199,10 @@ class Service extends Component
      * @throws \yii\base\InvalidConfigException
      * @throws \craft\errors\AssetException
      */
-    public function getEmbeddedAsset(Asset $asset): ?EmbeddedAsset
+    public function getEmbeddedAsset(?Asset $asset): ?EmbeddedAsset
     {
         // Embedded assets are just JSON files, so clearly if this isn't a JSON file it can't be an embedded asset
-        if ($asset->kind !== Asset::KIND_JSON) {
+        if ($asset?->kind !== Asset::KIND_JSON) {
             return null;
         }
 

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -24,7 +24,7 @@ class Variable
      * @param Asset $asset
      * @return EmbeddedAsset|null
      */
-    public function get(Asset $asset): ?EmbeddedAsset
+    public function get(?Asset $asset): ?EmbeddedAsset
     {
         return EmbeddedAssets::$plugin->methods->getEmbeddedAsset($asset);
     }


### PR DESCRIPTION
This let you call the `craft.embeddedassets.get(asset)` method from templates without having to check first whether `asset` is `null`.

If it is, just return `null`.